### PR TITLE
Support searching in relative paths with `paths` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,13 @@ Example
 
 Qt has private headers with a "<base>_p.h" suffix, and QtWebKit has platform specific implementation headers/sources with a "<base>Qt.<ext>" suffix.
 The following keymap setting would allow switching between "File.cpp" -> "FileQt.cpp" -> "FileQt.h" -> "File.h" -> "File_p.h" -> "File_p_p.h" -> ...
+It also would search for files in sibling `impl` and `include` folders.
 
     [
-        { "keys": ["alt+o"], "command": "switch_file_deluxe", "args": {"extensions": [".cpp", ".cxx", ".cc", ".c", "Qt.cpp", "Qt.h", ".hpp", ".hxx", ".h", "_p.h", "_p_p.h", ".ipp", ".inl", ".m", ".mm"]} }
+        { "keys": ["alt+o"], "command": "switch_file_deluxe", "args": {
+            "extensions": [".cpp", ".cxx", ".cc", ".c", "Qt.cpp", "Qt.h", ".hpp", ".hxx", ".h", "_p.h", "_p_p.h", ".ipp", ".inl", ".m", ".mm"],
+            "paths": ["../impl", "../include"]
+        } }
     ]
 
 **Note:** The dot has to be explicitely specified before extensions, unlike the standard switch_file command.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ SublimeSwitchFileDeluxe
 Switch header/source based on generic suffixes (not just the extension).
 
 If a file can't be found in the same directory, the command also searches for it in the directory of other already opened files.
+It can also search in relative paths specified with `"paths"` setting. For example if `"paths"` is `["..", "../impl", "internal"]`, then header/source will be searched in parent folder, in 'impl' sibling folder and in 'internal' subfolder.
 
 Example
 =======

--- a/switch_file_deluxe.py
+++ b/switch_file_deluxe.py
@@ -20,9 +20,12 @@ def commonBase(fileName, extensions):
     return base, ext
 
 class SwitchFileDeluxeCommand(sublime_plugin.WindowCommand):
-    def run(self, extensions=[]):
+    def run(self, extensions=[], paths=['.']):
         if not self.window.active_view():
             return
+
+        if '.' not in paths:  # always search in same path
+            paths.append('.')
 
         path = self.window.active_view().file_name()
         if not path:
@@ -48,15 +51,16 @@ class SwitchFileDeluxeCommand(sublime_plugin.WindowCommand):
             idx = (start + i) % len(extensions)
 
             new_file = base + extensions[idx]
-            new_path = os.path.join(dir, new_file)
-            if os.path.exists(new_path):
-                self.window.open_file(new_path)
-                return
-            else:
-                for d in dirsWithOpenedFiles:
-                    if os.path.exists(os.path.join(d, new_file)):
-                        self.window.open_file(os.path.join(d, new_file))
-                        return
+
+            for relative_path in paths:
+                new_path = os.path.normpath(os.path.join(dir, relative_path, new_file))
+                if os.path.exists(new_path):
+                    self.window.open_file(new_path)
+                    return
+            for d in dirsWithOpenedFiles:
+                if os.path.exists(os.path.join(d, new_file)):
+                    self.window.open_file(os.path.join(d, new_file))
+                    return
 
         # Fallback to the Goto menu only if the file matches one of the extensions.
         if base != file:


### PR DESCRIPTION
Setting `paths` for `["../impl", "internal", ".."]` will cause searching in:

1. `../impl` - `impl` sibling folder
2. `internal` - `internal` subfolder
3. `..` - parent

Regardeless of `path` setting it always searches in current folder